### PR TITLE
🔖 Change major version to 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "covidvobcich-api",
-  "version": "1.0.1",
+  "version": "2.0.1",
   "main": "lib/index.js",
   "author": "Petr Hovorka",
   "license": "MIT",


### PR DESCRIPTION
The old API that ran on VPS is considered as version 1.